### PR TITLE
populate verseText when props change

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -115,8 +115,11 @@ class VerseCheck extends React.Component {
   componentWillReceiveProps(nextProps) {
     this.setState({
       mode: undefined,
-      comments: undefined
+      comments: undefined,
+      verseText: undefined
     })
+    let {chapter, verse} = this.props.contextIdReducer.contextId.reference
+    this.verseText = this.props.resourcesReducer.bibles.targetLanguage[chapter][verse]
   }
 
   render() {


### PR DESCRIPTION
## This PR addresses:
This should fix cases where props update and verseText isn’t updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/7)
<!-- Reviewable:end -->
