### PR TITLE
Modal Pop-out for Target Translation

### DIFF
--- a/components/MyLanguageModal.js
+++ b/components/MyLanguageModal.js
@@ -1,0 +1,78 @@
+import React, { Component, PropTypes } from 'react'
+import { Modal, Button } from 'react-bootstrap'
+import MyTargetVerse from './MyTargetVerse'
+import ReactDOM from 'react-dom'
+
+class MyLanguageModal extends Component {
+
+  componentDidMount() {
+    let {chapter, currentVerse} = this.props
+    let verseReference = chapter.toString() + currentVerse.toString()
+    let currentVerseNode = this.refs[verseReference]
+    let element = ReactDOM.findDOMNode(currentVerseNode)
+    if (element) {
+      element.scrollIntoView()
+    }
+  }
+
+  render() {
+    let { show, onHide, targetLangBible, chapter, currentVerse } = this.props
+    let MyTargetLanguage = []
+    if (show) {
+      for (let key in targetLangBible[chapter]) {
+        if (targetLangBible[chapter].hasOwnProperty(key)) {
+          let verseText = targetLangBible[chapter][key]
+          let versePaneStyle = {};
+          if (key == currentVerse) {
+            if (key % 2 == 0) {
+              versePaneStyle = {borderLeft: '6px solid #2196F3', backgroundColor: '#e7e7e7', marginTop: '10px', color: '#000000', padding: '10px'}
+            } else {
+              versePaneStyle = {borderLeft: '6px solid #2196F3', marginTop: '10px', color: '#000000', padding: '10px'}
+            }
+          } else if (key % 2 == 0) {
+            versePaneStyle = {backgroundColor: '#e7e7e7', marginTop: '10px', color: '#000000', padding: '10px'}
+          } else {
+            versePaneStyle = {marginTop: '10px', color: '#000000', padding: '10px'}
+          }
+          MyTargetLanguage.push(
+            <MyTargetVerse
+              key={key}
+              chapter={chapter}
+              verse={parseInt(key, 10)}
+              verseText={verseText}
+              styles={versePaneStyle}
+              ref={chapter.toString() + key.toString()}
+            />
+          )
+        }
+      }
+    }
+
+    return (
+      <Modal show={show} onHide={onHide} bsSize="lg" aria-labelledby="contained-modal-title-sm">
+        <Modal.Header style={{ backgroundColor: "#333333" }} closeButton>
+          <Modal.Title id="contained-modal-title-sm"
+            style={{ textAlign: "center", color: "#FFFFFF" }}>
+
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body style={{padding: '0px', height: "550px", backgroundColor: "#FFFFFF", overflowY: "auto"}}>
+          {MyTargetLanguage}
+        </Modal.Body>
+        <Modal.Footer style={{ backgroundColor: "#333333" }}>
+          <Button bsStyle="danger" onClick={onHide}>Close</Button>
+        </Modal.Footer>
+      </Modal>
+    )
+  }
+}
+
+MyLanguageModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onHide: PropTypes.func.isRequired,
+  targetLangBible: PropTypes.object,
+  chapter: PropTypes.number,
+  currentVerse: PropTypes.number
+}
+
+export default MyLanguageModal

--- a/components/MyTargetVerse.js
+++ b/components/MyTargetVerse.js
@@ -1,0 +1,26 @@
+import React, { Component, PropTypes } from 'react'
+import { Col } from 'react-bootstrap'
+
+class MyTargetVerse extends Component {
+
+  render() {
+    let { chapter, verse, verseText, styles} = this.props
+    return (
+      <Col md={12} sm={12} xs={12} lg={12} style={styles}>
+        <div>
+          <b>{chapter + ":" + verse + " "}</b>
+          {verseText}
+        </div>
+      </Col>
+    )
+  }
+}
+
+MyTargetVerse.propTypes = {
+  chapter: PropTypes.number,
+  verse: PropTypes.number,
+  verseText: PropTypes.string,
+  styles: PropTypes.object
+}
+
+export default MyTargetVerse

--- a/components/selectArea.js
+++ b/components/selectArea.js
@@ -1,13 +1,15 @@
 import React from 'react'
-
+import {Glyphicon} from 'react-bootstrap'
 import style from '../css/style'
 import SelectionHelpers from '../utils/selectionHelpers'
+import MyLanguageModal from './MyLanguageModal'
 
 class SelectArea extends React.Component {
   constructor() {
     super();
     this.state = {
-      inBox: false
+      inBox: false,
+      modalVisibility: false
     }
   }
 
@@ -22,7 +24,7 @@ class SelectArea extends React.Component {
       text = document.selection.createRange().text;
     }
     if (text === "") {
-      //do nothing since an empty space was selected
+      // do nothing since an empty space was selected
     } else {
       let expression = '/' + text + '/g';
       let wordOccurencesArray = verseText.match(eval(expression));
@@ -101,11 +103,35 @@ class SelectArea extends React.Component {
 
   render() {
     let reference = this.props.contextIdReducer.contextId.reference
+    let bibles = this.props.resourcesReducer.bibles
+    let modal = <div/>
+    if (this.state.modalVisibility) {
+      modal = (
+        <MyLanguageModal
+          show={this.state.modalVisibility}
+          targetLangBible={bibles.targetLanguage}
+          chapter={reference.chapter}
+          currentVerse={reference.verse}
+          onHide={
+            () => {
+              this.setState({modalVisibility: false})
+            }
+          }
+        />
+      )
+    }
+
     return (
       <div>
-        <div style={{fontWeight: 'bold'}}>
-          Target Language
+        <div style={{float: 'right'}} onClick={() => {
+          this.setState({modalVisibility: true})
+        }}>
+          <Glyphicon glyph='fullscreen' style={{cursor: 'pointer'}}/>
+          {modal}
         </div>
+        <div style={{fontWeight: 'bold'}}>
+          Target Languagebb
+        </div>     
         <div style={{color: "#747474"}}>
           {reference.bookId} {reference.chapter + ':' + reference.verse}
         </div>
@@ -117,4 +143,4 @@ class SelectArea extends React.Component {
   }
 }
 
-module.exports = SelectArea
+export default SelectArea

--- a/components/selectArea.js
+++ b/components/selectArea.js
@@ -123,13 +123,13 @@ class SelectArea extends React.Component {
 
     return (
       <div>
-        <div style={{float: 'right'}} onClick={() => {
+        <div style={{float: "right"}} onClick={() => {
           this.setState({modalVisibility: true})
         }}>
-          <Glyphicon glyph='fullscreen' style={{cursor: 'pointer'}}/>
+          <Glyphicon glyph="fullscreen" style={{cursor: "pointer"}}/>
           {modal}
         </div>
-        <div style={{fontWeight: 'bold'}}>
+        <div style={{fontWeight: "bold"}}>
           Target Languagebb
         </div>     
         <div style={{color: "#747474"}}>


### PR DESCRIPTION
**This PR adds the following:**
 In VerseCheck: Modal Pop-out for Target Translation #863

**Expected behavior:**
opens a modal pop-out when the expand button in my target language is clicked  that displays more context

**Test**
click the expand button in `my target language area` and it should open a modal that displays more context of the current chapter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/12)
<!-- Reviewable:end -->
