### PR TITLE
Invalidate Selections if occurrences don't match current count.

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -116,6 +116,9 @@ class VerseCheck extends React.Component {
           tags: []
         });
       },
+      validateSelections: function(verseText) {
+        that.props.actions.validateSelections(verseText)
+      },
       toggleReminder: function() {
         that.props.actions.toggleReminder(that.props.loginReducer.userdata.username)
       }

--- a/components/selectArea.js
+++ b/components/selectArea.js
@@ -102,6 +102,9 @@ class SelectArea extends React.Component {
   }
 
   render() {
+    let {verseText} = this.props
+    this.props.actions.validateSelections(verseText)
+
     let reference = this.props.contextIdReducer.contextId.reference
     let bibles = this.props.resourcesReducer.bibles
     let modal = <div/>
@@ -132,7 +135,7 @@ class SelectArea extends React.Component {
         </div>
         <div style={{fontWeight: "bold"}}>
           Target Language
-        </div>     
+        </div>
         <div style={{color: "#747474"}}>
           {reference.bookId} {reference.chapter + ':' + reference.verse}
         </div>


### PR DESCRIPTION
## This PR addresses:
Invalidate Selections if occurrences don't match current count. It alerts the user so that they know their edit invalidated the selection that was previously made.

## To test:
Checkout branch of the same name in translationCore app where the logic that is called resides. When rendering the text it validates to see if the selections are still valid.

Make a selection, then edit the verse and modify the words in the selection. Upon saving the verse edit, you should be alerted that the selection was invalidated.

## TODO: 
Find a common place to check for this validation so that it doesn’t happen deep in the tool but somewhere at a higher level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/20)
<!-- Reviewable:end -->
