### PR TITLE
Edit verse area now knows what direction it is going

### DIFF
--- a/components/checkArea.js
+++ b/components/checkArea.js
@@ -13,7 +13,8 @@ let CheckArea = (props) => {
     modeArea = <EditVerseArea
       tags={props.tags}
       verseText={props.verseText}
-      actions={props.actions} />
+      actions={props.actions}
+      dir = {props.projectDetailsReducer.manifest.target_language.direction} />
     break
     case 'comment':
     modeArea = <CommentArea comment={props.comment} actions={props.actions} />

--- a/components/editVerseArea.js
+++ b/components/editVerseArea.js
@@ -30,7 +30,7 @@ let EditVerseArea = (props) => {
           componentClass='textarea'
           type='text'
           defaultValue={props.verseText}
-          style={{height: '9em'}}
+          style={{height: '9em', direction: props.dir}}
           onBlur={props.actions.handleEditVerse.bind(this)}
         />
       <div style={{marginTop: '5px', marginBottom: '-2px', fontSize: '0.9em'}}>


### PR DESCRIPTION
Addresses: https://github.com/unfoldingWord-dev/translationCore/issues/1094

How to test:
Load a project with a target language that is read from right to left. Edit a verse, it should now display properly in the text field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/21)
<!-- Reviewable:end -->
