### PR TITLE
Don't use state to render the verse or comment.

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -149,8 +149,8 @@ class VerseCheck extends React.Component {
       <MuiThemeProvider>
         <View {...this.props} actions={this.actions}
           mode={this.state.mode}
-          comment={this.state.comment !== undefined ? this.state.comment : this.props.commentsReducer.text}
-          verseText={this.state.verseText !== undefined ? this.state.verseText : this.verseText}
+          comment={this.props.commentsReducer.text}
+          verseText={this.verseText}
           tags={this.state.tags}
           dialogModalVisibility={this.state.dialogModalVisibility}
           goToNextOrPrevious={this.state.goToNextOrPrevious}

--- a/Container.js
+++ b/Container.js
@@ -107,8 +107,10 @@ class VerseCheck extends React.Component {
         })
       },
       saveEditVerse: function() {
-        let {targetVerse, loginReducer, actions} = that.props
-        let before = targetVerse;
+        let {loginReducer, actions, contextIdReducer, projectDetailsReducer, resourcesReducer} = that.props;
+        let {chapter, verse, bookId} = contextIdReducer.contextId.reference;
+        let bookAbbr = projectDetailsReducer.params.bookAbbr;
+        let before = resourcesReducer.bibles.targetLanguage[chapter][verse];
         let username = loginReducer.userdata.username;
         actions.addVerseEdit(before, that.state.verseText, that.state.tags, username);
         that.setState({

--- a/components/view.js
+++ b/components/view.js
@@ -50,7 +50,7 @@ class View extends React.Component {
     )
     return (
       <div style={{ margin: '10px' }}>
-        <DialogComponent 
+        <DialogComponent
           dialogModalVisibility={this.props.dialogModalVisibility}
           handleOpen={this.props.actions.handleOpenDialog}
           handleClose={this.props.actions.handleCloseDialog}
@@ -68,7 +68,7 @@ class View extends React.Component {
           <CheckArea {...this.props} />
         </Row>
         <Row style={{marginLeft: '0px', marginRight: '0px', height: '100%'}}>
-          <ActionsArea mode={this.props.mode} actions={this.props.actions} />
+          <ActionsArea {...this.props} />
         </Row>
         </Card>
         <Row style={{marginLeft: '0px', marginRight: '0px'}}>


### PR DESCRIPTION
## This PR addresses:
This issue was masking the fact that VerseEdit is not updating the application state's copy of the verse. Now that render is not using VerseCheck's state to display the verse, the edit looks like it did not take, but it did in the filesystem.

## To Test:
Edit a verse and/or comment, and they should still work. There are some cases where a bug in the toggle icons of the menu gets in the way but it happens without this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/22)
<!-- Reviewable:end -->
