### PR TITLE
Showing verse/chapter where applicable in modal now

### DIFF
--- a/components/MyTargetVerse.js
+++ b/components/MyTargetVerse.js
@@ -5,11 +5,18 @@ class MyTargetVerse extends Component {
 
   render() {
     let { chapter, verse, verseText, styles} = this.props
+    let chapterVerse
+
+    if(this.props.dir == "rtl"){
+      chapterVerse = verse + ":" + chapter + " "
+    }else{
+      chapterVerse = chapter + ":" + verse + " "
+    }
 
     return (
       <Col md={12} sm={12} xs={12} lg={12} style={styles}>
         <div style={{direction: this.props.dir}}>
-          <b>{chapter + ":" + verse + " "}</b>
+          <b>{chapterVerse}</b>
           {verseText}
         </div>
       </Col>


### PR DESCRIPTION
Addresses QA concerns on https://github.com/unfoldingWord-dev/translationCore/issues/1097

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/33)
<!-- Reviewable:end -->
