### PR TITLE
Added styling that prevents the select area from getting too big

### DIFF
--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -131,7 +131,7 @@ class SelectArea extends React.Component {
     }
 
     return (
-      <div>
+      <div style={{maxHeight: "185px", overflowY: "scroll"}}>
         <div style={{float: "right"}} onClick={() => {
           this.setState({modalVisibility: true})
         }}>


### PR DESCRIPTION
Addresses https://github.com/unfoldingWord-dev/translationCore/issues/1332

Minor styling changes. Make a verse really long by editing it and it should scroll now instead of getting gigantic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/35)
<!-- Reviewable:end -->
