### PR TITLE
Focus the text boxes on edit or comment

### DIFF
--- a/components/CommentArea.js
+++ b/components/CommentArea.js
@@ -9,7 +9,7 @@ let CommentArea = (props) => {
         Comment
       </div>
       <FormGroup controlId="formControlsTextarea">
-        <FormControl
+        <FormControl autoFocus
           componentClass='textarea'
           type='text'
           defaultValue={props.comment}

--- a/components/EditVerseArea.js
+++ b/components/EditVerseArea.js
@@ -29,7 +29,7 @@ let EditVerseArea = (props) => {
         Edit Verse
       </div>
       <FormGroup controlId='formControlsTextarea'>
-        <FormControl
+        <FormControl autoFocus
           componentClass='textarea'
           type='text'
           defaultValue={props.verseText}


### PR DESCRIPTION
Addresses https://github.com/unfoldingWord-dev/translationCore/issues/1405

Click edit or comment, the cursor should automatically go inside of the text box now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/38)
<!-- Reviewable:end -->
