### PR TITLE
Disable selection in comment/edit

### DIFF
--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -126,7 +126,8 @@ class SelectArea extends React.Component {
   render() {
     let {verseText, projectDetailsReducer} = this.props
     this.props.actions.validateSelections(verseText)
-
+    const { manifest, bookName } = projectDetailsReducer
+    
     let reference = this.props.contextIdReducer.contextId.reference
     let bibles = this.props.resourcesReducer.bibles
     let languageName = manifest.target_language ? manifest.target_language.name : null;

--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -126,8 +126,6 @@ class SelectArea extends React.Component {
   render() {
     let {verseText, projectDetailsReducer} = this.props
     this.props.actions.validateSelections(verseText)
-    const { manifest, bookName } = projectDetailsReducer
-    console.log(this.props)
 
     let reference = this.props.contextIdReducer.contextId.reference
     let bibles = this.props.resourcesReducer.bibles

--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -71,25 +71,47 @@ class SelectArea extends React.Component {
     verseText = this.props.verseText
     if (selections && selections.length > 0) {
       var selectionArray = SelectionHelpers.selectionArray(verseText, selections)
-      verseText = selectionArray.map((selection, index) =>
-        <span key={index} style={selection.selected ? { backgroundColor: 'var(--highlight-color)', cursor: 'pointer' } : {}}
-          onClick={selection.selected ? () => this.removeSelection(selection) : () => { }}>
-          {selection.text}
-        </span>
-      )
+      if(this.props.mode == "select"){
+        verseText = selectionArray.map((selection, index) =>
+          <span key={index} style={selection.selected ? { backgroundColor: 'var(--highlight-color)', cursor: 'pointer' } : {}}
+            onClick={selection.selected ? () => this.removeSelection(selection) : () => { }}>
+            {selection.text}
+          </span>
+        )
 
-      return (
-        <div onMouseUp={() => this.getSelectionText()} onMouseLeave={()=>this.inDisplayBox(false)} onMouseEnter={()=>this.inDisplayBox(true)}>
-          {verseText}
-        </div>
-      );
+        return (
+          <div onMouseUp={() => this.getSelectionText()} onMouseLeave={()=>this.inDisplayBox(false)} onMouseEnter={()=>this.inDisplayBox(true)}>
+            {verseText}
+          </div>
+        );
+      } else {
+        verseText = selectionArray.map((selection, index) =>
+          <span key={index} style={selection.selected ? { backgroundColor: 'var(--highlight-color)', cursor: 'pointer' } : {}}>
+            {selection.text}
+          </span>
+        )
+
+        return (
+          <div>
+            {verseText}
+          </div>
+        )
+      }
     } else {
       verseText = this.props.verseText;
-      return (
-        <div onMouseUp={() => this.getSelectionText()} onMouseLeave={()=>this.inDisplayBox(false)} onMouseEnter={()=>this.inDisplayBox(true)}>
-          {verseText}
-        </div>
-      );
+      if(this.props.mode == "select"){
+        return (
+          <div onMouseUp={() => this.getSelectionText()} onMouseLeave={()=>this.inDisplayBox(false)} onMouseEnter={()=>this.inDisplayBox(true)}>
+            {verseText}
+          </div>
+        );
+      } else {
+        return (
+          <div>
+            {verseText}
+          </div>
+        )
+      }
     }
   }
 
@@ -105,6 +127,7 @@ class SelectArea extends React.Component {
     let {verseText, projectDetailsReducer} = this.props
     this.props.actions.validateSelections(verseText)
     const { manifest, bookName } = projectDetailsReducer
+    console.log(this.props)
 
     let reference = this.props.contextIdReducer.contextId.reference
     let bibles = this.props.resourcesReducer.bibles


### PR DESCRIPTION
This addresses https://github.com/unfoldingWord-dev/translationCore/issues/1336

How to test this:
1. Load a project and tool
2. Make a selection on any check
3. Click on "edit" or "comment"
4. Try and modify the selection while editing or commenting on the verse
5. You should no longer be able to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/43)
<!-- Reviewable:end -->
