### PR TITLE
Working complicated selections

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -5,7 +5,7 @@
 import React from 'react'
 import View from './components/View'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import SelectionHelpers from './utils/selectionHelpers'
+import {optimizeSelections} from './utils/selectionHelpers'
 // constant declaration
 const NAMESPACE = "VerseCheck";
 
@@ -58,7 +58,7 @@ class VerseCheck extends React.Component {
       },
       changeSelections: function(selections) {
         // optimize the selections to address potential issues and save
-        selections = SelectionHelpers.optimizeSelections(that.verseText, selections);
+        selections = optimizeSelections(that.verseText, selections);
         props.actions.changeSelections(selections, props.loginReducer.userdata.username)
       },
       changeMode: function(mode) {

--- a/Container.js
+++ b/Container.js
@@ -5,7 +5,7 @@
 import React from 'react'
 import View from './components/View'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import {optimizeSelections} from './utils/selectionHelpers'
+import {optimizeSelections, normalizeString} from './utils/selectionHelpers'
 // constant declaration
 const NAMESPACE = "VerseCheck";
 
@@ -68,7 +68,9 @@ class VerseCheck extends React.Component {
       },
       changeSelections: function(selections) {
         // optimize the selections to address potential issues and save
-        selections = optimizeSelections(that.verseText, selections);
+        // normalize whitespace in case selection has contiguous whitespace that isn't captured
+        let verseText = normalizeString(that.verseText);
+        selections = optimizeSelections(verseText, selections);
         props.actions.changeSelections(selections, props.loginReducer.userdata.username)
       },
       changeMode: function(mode) {

--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -33,19 +33,19 @@ class SelectArea extends React.Component {
     if (selectedText === '') {} else {
       // get the text after the presceding selection and current span selection is in.
       let selectionRange = windowSelection.getRangeAt(0)
-      // get the index of what is selected
+      // get the character index of what is selected in context of the span it is in.
       let indexOfTextSelection = selectionRange.startOffset;
-      // get the container of the selection
+      // get the container of the selection, this is a strange object, that logs as a string.
       let textContainer = selectionRange.commonAncestorContainer;
-      // get all of the text in the selection
-      let textContent = textContainer.textContent;
-      // get the text presceding the selection but after the selection just prior to it
-      let postPrescedingText = textContainer ? textContent.slice(0,indexOfTextSelection) : '';
-      // must find length of text prior to it.
-      let prescedingText = '';
-      // get the parent that contains the textContainer
+      // get the parent span that contains the textContainer.
       let textSpan = textContainer ? textContainer.parentElement : undefined;
-      // if we have a span that holds text, see what we can get
+      // get all of the text in the selection's container similar to the span's innerText.
+      let textSpanContent = textSpan.innerText;
+      // get the text presceding the selection but after the selection just prior to it.
+      let postPrescedingText = textContainer ? textSpanContent.slice(0,indexOfTextSelection) : '';
+      // start with an empty string to prepend to for text presceding current span selection is in.
+      let prescedingText = '';
+      // if we have a span that holds text, see what presceding text we can extract.
       if (textSpan) {
         // get the previous sibling to start the loop
         let previousSibling = textSpan.previousSibling;

--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -14,14 +14,25 @@ class SelectArea extends React.Component {
   }
 
   getSelectionText() {
-    let verseText = this.props.verseText
+    let verseText = this.props.verseText;
     let text = "";
-    var selectedString = window.getSelection();
-    var indexOfTextSelection = selectedString.getRangeAt(0).startOffset;
-    if (selectedString) {
+    // windowSelection is an object with lots of data
+    let windowSelection = window.getSelection();
+    // getSelection is limited by same innerText node, and does not include span siblings
+    // indexOfTextSelection is broken by any other previous selection since it only knows its innerText node.
+    let indexOfTextSelection = windowSelection.getRangeAt(0).startOffset;
+    // must find length of text prior to it.
+    let selectionContainer = windowSelection.getRangeAt(0).commonAncestorContainer.parentElement;
+    let prescedingText = '';
+    // get the current span's innerText
+    if (selectionContainer) {
       text = window.getSelection().toString();
-    } else if (document.selection && document.selection.type != "Control") {
-      text = document.selection.createRange().text;
+      let previousSibling = selectionContainer.previousSibling;
+      while (previousSibling) {
+        prescedingText = previousSibling.innerText + prescedingText;
+        previousSibling = previousSibling.previousSibling;
+      }
+      console.log(prescedingText)
     }
     if (text === "") {
       // do nothing since an empty space was selected
@@ -29,10 +40,15 @@ class SelectArea extends React.Component {
       let expression = '/' + text + '/g';
       let wordoccurrencesArray = verseText.match(eval(expression));
       let occurrences = wordoccurrencesArray.length;
+
       let occurrence;
       let textBeforeSelection = verseText.slice(0, indexOfTextSelection);
+      textBeforeSelection = prescedingText + textBeforeSelection;
       if (textBeforeSelection.match(eval(expression))) {
-        occurrence = textBeforeSelection.match(eval(expression)).length + 1;
+        occurrence = textBeforeSelection.match(eval(expression)).length;
+        if (prescedingText === '') {
+          occurrence = occurrence + 1
+        }
       } else {
         occurrence = 1;
       }
@@ -42,7 +58,8 @@ class SelectArea extends React.Component {
         occurrence: occurrence,
         occurrences: occurrences
       }
-      this.addSelection(selection)
+      console.log(selection);
+      this.addSelection(selection);
     }
   }
 

--- a/components/SelectArea.js
+++ b/components/SelectArea.js
@@ -88,24 +88,13 @@ class SelectArea extends React.Component {
     let { selections } = this.props.selectionsReducer;
     verseText = this.props.verseText
     if (selections && selections.length > 0) {
-<<<<<<< HEAD
       let _selectionArray = selectionArray(verseText, selections)
       verseText = _selectionArray.map((selection, index) =>
-        <span key={index} style={selection.selected ? { backgroundColor: '#FDD910', cursor: 'pointer' } : {}}
+        <span key={index} style={selection.selected ? { backgroundColor: 'var(--highlight-color)', cursor: 'pointer' } : {}}
           onClick={selection.selected ? () => this.removeSelection(selection) : () => { }}>
           {selection.text}
         </span>
       )
-=======
-      var selectionArray = SelectionHelpers.selectionArray(verseText, selections)
-      if(this.props.mode == "select"){
-        verseText = selectionArray.map((selection, index) =>
-          <span key={index} style={selection.selected ? { backgroundColor: 'var(--highlight-color)', cursor: 'pointer' } : {}}
-            onClick={selection.selected ? () => this.removeSelection(selection) : () => { }}>
-            {selection.text}
-          </span>
-        )
->>>>>>> master
 
         return (
           <div onMouseUp={() => this.getSelectionText()} onMouseLeave={()=>this.inDisplayBox(false)} onMouseEnter={()=>this.inDisplayBox(true)}>

--- a/utils/selectionHelpers.js
+++ b/utils/selectionHelpers.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
  * @param {array}  ranges - array of ranges [[int,int],...]
  * @returns {array} - array of objects [obj,...]
  */
-module.exports.spliceStringOnRanges = function(string, ranges) {
+export const spliceStringOnRanges = (string, ranges) => {
   var selectionArray = [] // response
   // sort ranges - this ensures we build the string correctly and don't miss selections
   // concat overlaps - should not be a concern here but might help rendering bugs
@@ -53,7 +53,7 @@ module.exports.spliceStringOnRanges = function(string, ranges) {
  * @param {array} selections - array of selections [obj,...]
  * @returns {array} - array of range objects
  */
-module.exports.selectionsToRanges = function(string, selections) {
+export const selectionsToRanges = (string, selections) => {
   var ranges = []
     selections.forEach(function(selection) {
       if (string !== undefined && string.includes(selection.text)) {
@@ -85,7 +85,7 @@ module.exports.selectionsToRanges = function(string, selections) {
  * @param {array} selections - array of selections [obj,...]
  * @returns {array} - array of objects
  */
-module.exports.selectionArray = function(string, selections) {
+export const selectionArray = (string, selections) => {
   var selectionArray = []
   var ranges = module.exports.selectionsToRanges(string, selections)
   selectionArray = module.exports.spliceStringOnRanges(string, ranges)
@@ -105,7 +105,7 @@ module.exports.selectionArray = function(string, selections) {
  * @param {array}  ranges - array of ranges [[int,int],...]
  * @returns {array} - array of optimized ranges [[int,int],...]
  */
-module.exports.optimizeRanges = function(ranges) {
+export const optimizeRanges = (ranges) => {
   var optimizedRanges = [] // response
   ranges = _.sortBy(ranges, function(range) { return range[1] })// order ranges by end char index as secondary
   ranges = _.sortBy(ranges, function(range) { return range[0] })// order ranges by start char index as primary
@@ -141,7 +141,7 @@ module.exports.optimizeRanges = function(ranges) {
  * @param {array} ranges - array of ranges [[int,int],...]
  * @returns {array} - array of selection objects
  */
- module.exports.rangesToSelections = function(string, ranges) {
+ export const rangesToSelections = (string, ranges) => {
    let selections = []
    ranges.forEach(function(range, index) {
      let start = range[0], end = range[1]
@@ -177,7 +177,7 @@ module.exports.optimizeRanges = function(ranges) {
  * @param {array}  selections - array of selection objects [Obj,...]
  * @returns {array} - array of selection objects
  */
-module.exports.optimizeSelections = function(string, selections) {
+export const optimizeSelections = (string, selections) => {
   let optimizedSelections // return
   var ranges = module.exports.selectionsToRanges(string, selections).map( rangeObject => rangeObject.range ) // get char ranges of each selection
   ranges = module.exports.optimizeRanges(ranges) // optimize the ranges
@@ -208,7 +208,25 @@ module.exports.optimizeSelections = function(string, selections) {
 // ]
 // console.log(module.exports.optimizeSelections(string, selections))
 
-
+/**
+ * @description Function that count occurrences of a substring in a string
+ * @param {String} string - The string to search in
+ * @param {String} subString - The sub string to search for
+ * @returns {Integer} - the count of the occurrences
+ * @see http://stackoverflow.com/questions/4009756/how-to-count-string-occurrence-in-string/7924240#7924240
+ * modified to fit our use cases, return zero for '' substring, and no use case for overlapping.
+ */
+export const occurrencesInString = (string, subString) => {
+ if (subString.length <= 0) return 0
+ var n = 0, pos = 0, step = subString.length
+ while (true) {
+   pos = string.indexOf(subString, pos)
+   if (pos === -1) break
+   ++n
+   pos += step
+ }
+ return n
+}
 
 
 

--- a/utils/selectionHelpers.js
+++ b/utils/selectionHelpers.js
@@ -227,6 +227,15 @@ export const occurrencesInString = (string, subString) => {
  }
  return n
 }
+/**
+ * @description Function that normalizes a string including whitespace
+ * @param {String} string - the string to normalize
+ * @preturns {String} - The returned normalized string
+ */
+export const normalizeString = (string) => {
+  string = string.replace(/\s+/g, ' ');
+  return string;
+}
 
 
 

--- a/utils/selectionHelpers.js
+++ b/utils/selectionHelpers.js
@@ -187,7 +187,6 @@ module.exports.optimizeSelections = function(string, selections) {
 //
 // Use the following lines to test the previous function
 // var string = "0123456789qwertyuiopasdfghjklzxcvbnmtyui01234567890"
-// var string = "0123456789qwertyuiopasdfghjklzxcvbnmtyui01234567890"
 // var selections = [
 //   { text: '234', occurrence: 2, occurrences: 2 },
 // ]
@@ -200,6 +199,12 @@ module.exports.optimizeSelections = function(string, selections) {
 //   { text: 'yui', occurrence: 1, occurrences: 2 },
 //   { text: 'yui', occurrence: 2, occurrences: 2 },
 //   { text: 'asdfghjklzxcvbnmtyui0', occurrence: 1, occurrences: 1 }
+// ]
+// the following tests a repeated occurrence after an early selection is made
+// var selections = [
+//   { text: '234', occurrence: 1, occurrences: 2 },
+//   { text: 'yui', occurrence: 2, occurrences: 2 },
+//   { text: '0', occurrence: 3, occurrences: 3 }
 // ]
 // console.log(module.exports.optimizeSelections(string, selections))
 


### PR DESCRIPTION
## This PR Addresses:
- [x] You can now select a word early in the text, and make additional selections of the second/third occurrence of a word that occurs multiple times without it selecting the first occurrence.
- [x] You can now select a phrase with more than one space and/or a line break between words.

## To Test this PR:
1. Find a verse with multiple occurrences of a word. 
2. Select a word before any of those occurrences.
3. Select the last occurrence.
4. Deselect and keep trying to break it.
5. Edit a verse and add more than one space in a phrase.
6. Save it, make a selection that transcends where the whitespace was added.
7. Verify that it worked.
8. Repeat with a line break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/45)
<!-- Reviewable:end -->
