### PR TITLE
Remove Highlighting From Verse Check When Not Applicable

### DIFF
--- a/components/CheckArea.js
+++ b/components/CheckArea.js
@@ -48,7 +48,7 @@ class CheckArea extends Component {
       case 'default':
       default:
         modeArea = (
-          <div className='disableHighlight' style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+          <div style={{ WebkitUserSelect:'none', display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
             <DirectionsArea selectionsReducer={selectionsReducer} quote={contextIdReducer.contextId.quote} />
           </div>
         );

--- a/components/CheckArea.js
+++ b/components/CheckArea.js
@@ -48,7 +48,7 @@ class CheckArea extends Component {
       case 'default':
       default:
         modeArea = (
-          <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+          <div className='disableHighlight' style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
             <DirectionsArea selectionsReducer={selectionsReducer} quote={contextIdReducer.contextId.quote} />
           </div>
         );

--- a/components/DefaultArea.js
+++ b/components/DefaultArea.js
@@ -60,7 +60,7 @@ class DefaultArea extends React.Component {
 
     if (this.props.mode === "select") {
       return (
-        <div className='disableHighlight' style={{ display: "flex", flex: "1", justifyContent: "center", alignItems: "center", overflow: "auto" }}>
+        <div style={{WebkitUserSelect:'none', display: "flex", flex: "1", justifyContent: "center", alignItems: "center", overflow: "auto" }}>
           <DirectionsArea
             dontShowTranslation={true}
             selectionsReducer={this.props.selectionsReducer}
@@ -70,7 +70,7 @@ class DefaultArea extends React.Component {
       );
     }
     return (
-      <div className='disableHighlight' style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+      <div style={{WebkitUserSelect:'none', flex: 1, display: 'flex', flexDirection: 'column'}}>
         <div style={style.verseTitle}>
           <div style={{display: 'flex', flexDirection: 'column'}}>
               <span style={style.pane.title}>

--- a/components/DefaultArea.js
+++ b/components/DefaultArea.js
@@ -60,7 +60,7 @@ class DefaultArea extends React.Component {
 
     if (this.props.mode === "select") {
       return (
-        <div style={{ display: "flex", flex: "1", justifyContent: "center", alignItems: "center", overflow: "auto" }}>
+        <div className='disableHighlight' style={{ display: "flex", flex: "1", justifyContent: "center", alignItems: "center", overflow: "auto" }}>
           <DirectionsArea
             dontShowTranslation={true}
             selectionsReducer={this.props.selectionsReducer}

--- a/components/DefaultArea.js
+++ b/components/DefaultArea.js
@@ -70,7 +70,7 @@ class DefaultArea extends React.Component {
       );
     }
     return (
-      <div style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+      <div className='disableHighlight' style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
         <div style={style.verseTitle}>
           <div style={{display: 'flex', flexDirection: 'column'}}>
               <span style={style.pane.title}>


### PR DESCRIPTION
#### This pull request addresses:
This PR makes the select mode area the only place where a user can select/highlight when using the checking tool.
#2306

#### How to test this pull request:
`git checkout enhancement/jay/remove-highlight/2295`
Try highlighting the areas specified in #2295 and make sure they are not selectable/highlightable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/62)
<!-- Reviewable:end -->
