### PR TITLE
Text no longer overflows left panel of select area

### DIFF
--- a/css/Style.js
+++ b/css/Style.js
@@ -3,12 +3,14 @@ var style = {
     contentLTR: {
       direction: 'ltr',
       flex: 'auto',
-      padding: '0 15px 10px'
+      padding: '0 15px 10px',
+      overflowY: "auto"
     },
     contentRTL: {
       direction: 'rtl',
       flex: 'auto',
-      padding: '0 15px 10px'
+      padding: '0 15px 10px',
+      overflowY: "auto"
     },
     title: {
       fontWeight: 'bold'


### PR DESCRIPTION
# Tests:
- Open a check with a verse that overflows the left panel of the verseCheck and verify that it doesn't overflow but instead a scrollbar shows up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/64)
<!-- Reviewable:end -->
