### PR TITLE
fixed Overlapping of reason codes on verse edit

### DIFF
--- a/components/EditVerseArea.js
+++ b/components/EditVerseArea.js
@@ -11,10 +11,10 @@ let EditVerseArea = (props) => {
     ["wordChoice", "Word Choice"],
     ["other", "Other"]
   ]
-  const checkboxes = tagList.map( tag =>
+  const checkboxes = tagList.map(tag =>
     <Checkbox key={tag[0]} inline checked={props.tags.includes(tag[0])}
       disabled={!props.verseChanged}
-      style={props.verseChanged ? {width: '33.3%', marginLeft: '0px', color: 'var(--text-color-dark)'} : {width: '33.3%', marginLeft: '0px', color: 'var(--text-color-light)'}}
+      style={props.verseChanged ? {width: '33.3%', marginLeft: '10px', marginRight: '10px', color: 'var(--text-color-dark)'} : {width: '33.3%', marginLeft: '10px', marginRight: '10px', color: 'var(--text-color-light)'}}
       onChange={props.actions.handleTagsCheckbox.bind(this, tag[0])}
     >
       {tag[1]}


### PR DESCRIPTION
# Tests
- Open any project and go to the verse edit area in the verse check adjust the width of the tC app window and the reason codes should not overlap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/65)
<!-- Reviewable:end -->
