### PR TITLE
updated verse check check boxes again

### DIFF
--- a/components/EditVerseArea.js
+++ b/components/EditVerseArea.js
@@ -3,16 +3,34 @@ import {Checkbox, Glyphicon, FormGroup, FormControl} from 'react-bootstrap'
 import style from '../css/Style';
 
 let EditVerseArea = (props) => {
-  const tagList = [
+  const tagList1 = [
     ["spelling", "Spelling"],
     ["punctuation", "Punctuation"],
-    ["grammar", "Grammar"],
-    ["meaning", "Meaning"],
     ["wordChoice", "Word Choice"],
+  ]
+
+  const tagList2 = [
+    ["meaning", "Meaning"],
+    ["grammar", "Grammar"],
     ["other", "Other"]
   ]
-  const checkboxes = tagList.map(tag =>
-    <Checkbox key={tag[0]} inline checked={props.tags.includes(tag[0])}
+
+  const checkboxesColumn1 = tagList1.map(tag =>
+    <Checkbox
+      key={tag[0]}
+      checked={props.tags.includes(tag[0])}
+      disabled={!props.verseChanged}
+      style={props.verseChanged ? {width: '33.3%', marginLeft: '10px', marginRight: '10px', color: 'var(--text-color-dark)'} : {width: '33.3%', marginLeft: '10px', marginRight: '10px', color: 'var(--text-color-light)'}}
+      onChange={props.actions.handleTagsCheckbox.bind(this, tag[0])}
+    >
+      {tag[1]}
+    </Checkbox>
+  )
+
+  const checkboxesColumn2 = tagList2.map(tag =>
+    <Checkbox
+      key={tag[0]}
+      checked={props.tags.includes(tag[0])}
       disabled={!props.verseChanged}
       style={props.verseChanged ? {width: '33.3%', marginLeft: '10px', marginRight: '10px', color: 'var(--text-color-dark)'} : {width: '33.3%', marginLeft: '10px', marginRight: '10px', color: 'var(--text-color-light)'}}
       onChange={props.actions.handleTagsCheckbox.bind(this, tag[0])}
@@ -39,13 +57,20 @@ let EditVerseArea = (props) => {
           onInput={props.actions.checkVerse.bind(this)}
         />
       <div style={{flex: '0 0 65px', marginTop: '5px', fontSize: '0.9em'}}>
-          {checkBoxText}
-          <br />
-          {checkboxes}
+        {checkBoxText}
+        <br />
+        <div style={{ display: 'flex' }}>
+          <div style={{ flex: '1' }}>
+            {checkboxesColumn1}
+          </div>
+          <div style={{ flex: '1' }}>
+            {checkboxesColumn2}
+          </div>
         </div>
+      </div>
       </FormGroup>
     </div>
   )
 }
 
-module.exports = EditVerseArea
+export default EditVerseArea;


### PR DESCRIPTION
- Reason codes on verse edit should not overlap

# Test
- Open the verse edit area and make sure the reason codes don't overlap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/66)
<!-- Reviewable:end -->
