### PR TITLE
Reload state selections on mode change and minor syntax refactor

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -2,16 +2,17 @@
   * @author Christopher Klpap
   * @description This component displays the Verse so selection, edit and comments can be made
   */
-import React from 'react'
-import View from './components/View'
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import {optimizeSelections, normalizeString} from './utils/selectionHelpers'
+import React from 'react';
+import View from './components/View';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import {optimizeSelections, normalizeString} from './utils/selectionHelpers';
 
 class VerseCheck extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
+    const mode = props.selectionsReducer.selections.length > 0 ? 'default' : 'select';
     this.state = {
-      mode: props.selectionsReducer.selections.length > 0 ? 'default' : 'select',
+      mode: mode,
       comment: undefined,
       commentChanged: false,
       verseText: undefined,
@@ -20,9 +21,9 @@ class VerseCheck extends React.Component {
       tags: [],
       dialogModalVisibility: false,
       goToNextOrPrevious: null
-    }
+    };
 
-    let that = this
+    let _this = this;
 
     this.tagList = [
       ["spelling", "Spelling"],
@@ -34,164 +35,165 @@ class VerseCheck extends React.Component {
     ]
 
     this.actions = {
-      handleGoToNext: function() {
-        if (!that.props.loginReducer.loggedInUser) {
-          that.props.actions.selectModalTab(1, 1, true);
-          that.props.actions.openAlertDialog("You must be logged in to save progress");
+      handleGoToNext() {
+        if (!_this.props.loginReducer.loggedInUser) {
+          _this.props.actions.selectModalTab(1, 1, true);
+          _this.props.actions.openAlertDialog("You must be logged in to save progress");
           return;
         }
-        props.actions.goToNext()
+        props.actions.goToNext();
       },
-      handleGoToPrevious: function() {
-        if (!that.props.loginReducer.loggedInUser) {
-          that.props.actions.selectModalTab(1, 1, true);
-          that.props.actions.openAlertDialog("You must be logged in to save progress");
+      handleGoToPrevious() {
+        if (!_this.props.loginReducer.loggedInUser) {
+          _this.props.actions.selectModalTab(1, 1, true);
+          _this.props.actions.openAlertDialog("You must be logged in to save progress");
           return;
         }
-        props.actions.goToPrevious()
+        props.actions.goToPrevious();
       },
       handleOpenDialog(goToNextOrPrevious) {
-        that.setState({goToNextOrPrevious})
-        that.setState({dialogModalVisibility: true});
+        _this.setState({goToNextOrPrevious})
+        _this.setState({dialogModalVisibility: true});
       },
       handleCloseDialog() {
-        that.setState({dialogModalVisibility: false});
+        _this.setState({dialogModalVisibility: false});
       },
       skipToNext() {
-        that.setState({dialogModalVisibility: false});
-        props.actions.goToNext()
+        _this.setState({dialogModalVisibility: false});
+        props.actions.goToNext();
       },
       skipToPrevious() {
-        that.setState({dialogModalVisibility: false});
-        props.actions.goToPrevious()
+        _this.setState({dialogModalVisibility: false});
+        props.actions.goToPrevious();
       },
-      changeSelectionsInLocalState: function(selections) {
-        that.setState({ selections });
+      changeSelectionsInLocalState(selections) {
+        _this.setState({ selections });
       },
-      changeMode: function(mode) {
-        let newState = that.state
-        newState.mode = mode
-        that.setState(newState)
+      changeMode(mode) {
+        _this.setState({
+          mode: mode,
+          selections: _this.props.selectionsReducer.selections
+        });
       },
-      handleComment: function(e) {
-        const comment = e.target.value
-        let newState = that.state
-        newState.comment = comment
-        that.setState(newState)
+      handleComment(e) {
+        const comment = e.target.value;
+        _this.setState({
+          comment: comment
+        });
       },
-      checkComment: function(e) {
+      checkComment(e) {
         const newcomment = e.target.value || "";
-        const oldcomment = that.props.commentsReducer.text || "";
-
-        that.setState({
+        const oldcomment = _this.props.commentsReducer.text || "";
+        _this.setState({
           commentChanged: newcomment !== oldcomment
         })
       },
-      cancelComment: function(e) {
-        that.setState({
+      cancelComment(e) {
+        _this.setState({
           mode: 'default',
+          selections: _this.props.selectionsReducer.selections,
           comment: undefined,
           commentChanged: false
-        })
+        });
       },
-      saveComment: function() {
-        if (!that.props.loginReducer.loggedInUser) {
-          that.props.actions.selectModalTab(1, 1, true);
-          that.props.actions.openAlertDialog("You must be logged in to leave a comment", 5);
+      saveComment() {
+        if (!_this.props.loginReducer.loggedInUser) {
+          _this.props.actions.selectModalTab(1, 1, true);
+          _this.props.actions.openAlertDialog("You must be logged in to leave a comment", 5);
           return;
         }
-        that.props.actions.addComment(that.state.comment, that.props.loginReducer.userdata.username)
-        that.setState({
+        _this.props.actions.addComment(_this.state.comment, _this.props.loginReducer.userdata.username);
+        _this.setState({
           mode: 'default',
+          selections: _this.props.selectionsReducer.selections,
           comment: undefined,
           commentChanged: false
-        })
+        });
       },
-      handleTagsCheckbox: function(tag, e) {
-        let newState = that.state
-        if (newState.tags === undefined) newState.tags = []
+      handleTagsCheckbox(tag, e) {
+        let newState = _this.state;
+        if (newState.tags === undefined) newState.tags = [];
         if (!newState.tags.includes(tag)) {
-          newState.tags.push(tag)
+          newState.tags.push(tag);
         } else {
-          newState.tags = newState.tags.filter( _tag => _tag !== tag)
+          newState.tags = newState.tags.filter( _tag => _tag !== tag);
         }
-        that.setState(newState)
+        _this.setState(newState);
       },
-      handleEditVerse: function(e) {
-        const verseText = e.target.value
-        let newState = that.state
-        newState.verseText = verseText
-        that.setState(newState)
+      handleEditVerse(e) {
+        const verseText = e.target.value;
+        _this.setState({
+          verseText: verseText
+        });
       },
-      checkVerse: function(e) {
-        let {chapter, verse} = that.props.contextIdReducer.contextId.reference;
+      checkVerse(e) {
+        let {chapter, verse} = _this.props.contextIdReducer.contextId.reference;
         const newverse = e.target.value || "";
-        const oldverse = that.props.resourcesReducer.bibles.targetLanguage[chapter][verse] || "";
-
+        const oldverse = _this.props.resourcesReducer.bibles.targetLanguage[chapter][verse] || "";
         if (newverse === oldverse) {
-          that.setState({
+          _this.setState({
             verseChanged: false,
             tags: []
-          })
+          });
         } else {
-          that.setState({
+          _this.setState({
             verseChanged: true
-          })
+          });
         }
       },
-      cancelEditVerse: function() {
-        that.setState({
+      cancelEditVerse() {
+        _this.setState({
           mode: 'default',
+          selections: _this.props.selectionsReducer.selections,
           verseText: undefined,
           verseChanged: false,
           tags: []
-        })
+        });
       },
-      saveEditVerse: function() {
-        let {loginReducer, actions, contextIdReducer, resourcesReducer} = that.props;
+      saveEditVerse() {
+        let {loginReducer, actions, contextIdReducer, resourcesReducer} = _this.props;
         let {chapter, verse} = contextIdReducer.contextId.reference;
         let before = resourcesReducer.bibles.targetLanguage[chapter][verse];
         let username = loginReducer.userdata.username;
         // verseText state is undefined if no changes are made in the text box.
         if (!loginReducer.loggedInUser) {
-          that.props.actions.selectModalTab(1, 1, true);
-          that.props.actions.openAlertDialog("You must be logged in to edit a verse");
+          _this.props.actions.selectModalTab(1, 1, true);
+          _this.props.actions.openAlertDialog("You must be logged in to edit a verse");
           return;
         }
 
         const save = () => {
-          actions.addVerseEdit(before, that.state.verseText, that.state.tags, username);
-          that.setState({
+          actions.addVerseEdit(before, _this.state.verseText, _this.state.tags, username);
+          _this.setState({
             mode: 'default',
+            selections: _this.props.selectionsReducer.selections,
             verseText: undefined,
             verseChanged: false,
             tags: []
           });
         }
-
-        if (that.state.verseText) {  // if verseText === "" is false
+        if (_this.state.verseText) {  // if verseText === "" is false
           save();
         } else {
           // alert the user if the text is blank
           let message = 'You are saving a blank verse. Please confirm.';
-          that.props.actions.openOptionDialog(message, (option)=> {
+          _this.props.actions.openOptionDialog(message, (option)=> {
             if (option !== "Cancel") save();
-            that.props.actions.closeAlertDialog();
+            _this.props.actions.closeAlertDialog();
           }, "Save Blank Verse", "Cancel");
         }
-
       },
-      validateSelections: (verseText) => {
-        that.props.actions.validateSelections(verseText)
+      validateSelections(verseText) {
+        _this.props.actions.validateSelections(verseText)
       },
-      toggleReminder: () => {
-        that.props.actions.toggleReminder(that.props.loginReducer.userdata.username)
+      toggleReminder() {
+        _this.props.actions.toggleReminder(_this.props.loginReducer.userdata.username)
       },
-      openAlertDialog: (message) => {
-        that.props.actions.openAlertDialog(message)
+      openAlertDialog(message) {
+        _this.props.actions.openAlertDialog(message)
       },
-      selectModalTab: (tab, section, vis) => {
-        that.props.actions.selectModalTab(tab, section, vis);
+      selectModalTab(tab, section, vis) {
+        _this.props.actions.selectModalTab(tab, section, vis);
       }
     }
   }
@@ -204,27 +206,26 @@ class VerseCheck extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.contextIdReducer.contextId != this.props.contextIdReducer.contextId) {
       let selections = Array.from(nextProps.selectionsReducer.selections);
+      const mode = nextProps.selectionsReducer.selections.length > 0 ? 'default' : 'select';
       this.setState({
-        mode: nextProps.selectionsReducer.selections.length > 0 ? 'default' : 'select',
+        mode: mode,
         comments: undefined,
         verseText: undefined,
         selections,
         tags: []
-      })
+      });
     }
   }
 
   cancelSelection() {
-    this.setState({
-      mode: 'default',
-      selections: this.props.selectionsReducer.selections
-    })
+    this.actions.changeSelectionsInLocalState(this.props.selectionsReducer.selections);
+    this.actions.changeMode('default');
   }
 
   clearSelection() {
     this.setState({
       selections: []
-    })
+    });
   }
 
   saveSelection() {
@@ -232,9 +233,7 @@ class VerseCheck extends React.Component {
     // optimize the selections to address potential issues and save
     let selections = optimizeSelections(verseText, this.state.selections);
     this.props.actions.changeSelections(selections, this.props.loginReducer.userdata.username);
-    this.setState({
-      mode: 'default'
-    })
+    this.actions.changeMode('default');
   }
 
   verseText() {
@@ -244,10 +243,10 @@ class VerseCheck extends React.Component {
     let verseText = "";
     if (targetLanguage && targetLanguage[chapter] && bookId == bookAbbr) {
       verseText = targetLanguage[chapter][verse] || "";
-      // normalize whitespace in case selection has contiguous whitespace that isn't captured
+      // normalize whitespace in case selection has contiguous whitespace _this isn't captured
       verseText = normalizeString(verseText);
     }
-    return verseText
+    return verseText;
   }
 
   render() {


### PR DESCRIPTION
## To test this PR:
Follow the instructions and ensure that the previous bug does not occur.

The below behavior is now fixed, see *

- Open a project in tW and make a selection.
- Click Save Changes
- Click Edit, copy all of the text to the clipboard, delete all of the verse text, and then check the Other box
- Click Save Changes, then Save Blank Verse, and then OK.
- Click Edit, paste the text back in, then click the Other box
- Click Save Changes
- Notice that the previously selected text no longer shows as being selected.
- Click Select
- *Notice that the previously selected text again shows as being selected in the Edit box
- Click Cancel
- Notice that the previously selected text no longer shows as being selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/73)
<!-- Reviewable:end -->
