### PR TITLE
Add renderTimestamp to mount to fix initial deselection bug

### DIFF
--- a/components/RenderSelectionTextComponent.js
+++ b/components/RenderSelectionTextComponent.js
@@ -7,6 +7,11 @@ import * as stringHelpers from '../helpers/stringHelpers'
 
 class RenderSelectionTextComponent extends Component {
 
+  componentWillMount() {
+    // track when the selections change to prevent false clicks of removals
+    this.renderTimestamp = Date.now();
+  }
+
   componentWillReceiveProps(nextProps) {
     // track when the selections change to prevent false clicks of removals
     if (!_.isEqual(this.props.selections, nextProps.selections)) {


### PR DESCRIPTION
### This PR addresses
Previous selections weren't able to be unselected by simply clicking on the selection like before.
They were only unselectable after selecting something.
The component lifecycle didn't handle mount but did handle new props.

### To Test this PR
- Navigate to check with selection already made
- Click "Select" to go to select mode
- Make sure you can deselect something already selected by clicking on a selection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/74)
<!-- Reviewable:end -->
