### PR TITLE
New Filtering Function To Remove Specified Markers

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -3,6 +3,7 @@
   * @description This component displays the Verse so selection, edit and comments can be made
   */
 import React from 'react';
+import usfmjs from 'usfm-js';
 import View from './components/View';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {optimizeSelections, normalizeString} from './utils/selectionHelpers';
@@ -250,6 +251,7 @@ class VerseCheck extends React.Component {
   }
 
   render() {
+    let verseText = usfmjs.removeMarker(this.verseText())
     return (
       <MuiThemeProvider>
         <View {...this.props} actions={this.actions}
@@ -259,7 +261,7 @@ class VerseCheck extends React.Component {
           mode={this.state.mode}
           comment={this.props.commentsReducer.text}
           commentChanged={this.state.commentChanged}
-          verseText={this.verseText()}
+          verseText={verseText}
           verseChanged={this.state.verseChanged}
           selections={this.state.selections}
           tags={this.state.tags}


### PR DESCRIPTION
#### This pull request addresses:
This PR utilizes the new filtering function in the usfm module to remove extra, unneeded tags.

#### How to test this pull request:
Checkout branch ```enhancement/jay/filter-footnotes/1941```
on Scripture Pane, and Verse Check (this is assuming the usfm latetest module with the filtering function has already been merged with develop)
and open an eph book on tN and find the check for 1:1 and ensure there are no footnotes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/76)
<!-- Reviewable:end -->
