### PR TITLE
Added Fixes For Handling USFM 3 formatted Bibles

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -244,6 +244,7 @@ class VerseCheck extends React.Component {
     let verseText = "";
     if (targetLanguage && targetLanguage[chapter] && bookId == bookAbbr) {
       verseText = targetLanguage[chapter][verse] || "";
+      if (Array.isArray(verseText)) verseText = verseText[0];
       // normalize whitespace in case selection has contiguous whitespace _this isn't captured
       verseText = normalizeString(verseText);
     }


### PR DESCRIPTION
This PR adds functionality to check for using a string vs. an array in the render method.
I believe the PR in the usfm-js module is a requirement for this to function properly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/77)
<!-- Reviewable:end -->
