### PR TITLE
Feature - #1279 - Adds titles to expanded target language pane

### DIFF
--- a/__tests__/MyLanguageModal.test.js
+++ b/__tests__/MyLanguageModal.test.js
@@ -29,7 +29,7 @@ describe('Test MyLanguageModal component',()=>{
         }
       }
     };
-    const expectedTitle = props['projectDetailsReducer']['manifest']['project']['name'];
+    const expectedTitle = props.projectDetailsReducer.manifest.project.name;
     const enzymeWrapper = shallow(<MyLanguageModal {...props} />);
     validateModalTitle(enzymeWrapper, expectedTitle);
   });

--- a/__tests__/MyLanguageModal.test.js
+++ b/__tests__/MyLanguageModal.test.js
@@ -1,0 +1,42 @@
+/* eslint-env jest */
+
+import React from 'react';
+import MyLanguageModal from '../src/components/MyLanguageModal';
+import {shallow} from 'enzyme';
+import {Modal} from 'react-bootstrap';
+
+// Tests for MyLanguageModal React Component
+describe('Test MyLanguageModal component',()=>{
+  test('Tests that the modal\'s title is displayed', () => {
+    const props = {
+      show: true,
+      onHide: jest.fn(),
+      targetLangBible: {
+        1: {
+          1: "This is verse 1",
+          2: "This is verse 2",
+          3: "This is verse 3",
+          4: "This is verse 4"
+        }
+      },
+      chapter: 1,
+      currentVerse: 1,
+      projectDetailsReducer: {
+        manifest: {
+          project: {
+            name: 'My Book'
+          }
+        }
+      }
+    };
+    const expectedTitle = props['projectDetailsReducer']['manifest']['project']['name'];
+    const enzymeWrapper = shallow(<MyLanguageModal {...props} />);
+    validateModalTitle(enzymeWrapper, expectedTitle);
+  });
+});
+
+function validateModalTitle(enzymeWrapper, expectedTitle) {
+  const titleHeader = enzymeWrapper.find(Modal.Title).render().find('h4');
+  expect(titleHeader.length).toEqual(1);
+  expect(titleHeader.html()).toContain(expectedTitle);
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.1.0",
     "jsdom": "^11.3.0",
-    "react-test-renderer": "^15.6.1"
+    "react-test-renderer": "^15.6.1",
+    "react-bootstrap": "^0.30.7"
   },
   "dependencies": {
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -29,19 +29,25 @@
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "eslint": "^4.7.2",
+    "enzyme": "^2.9.1",
+    "eslint": "^4.10.0",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.1.0",
     "jsdom": "^11.3.0",
+    "react": "^15.6.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-bootstrap": "^0.30.10",
+    "react-dnd": "^2.5.4",
+    "react-dnd-html5-backend": "^2.5.4",
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.6",
+    "react-remarkable": "^1.1.3",
+    "react-test-renderer": "^15.6.2",
     "react-test-renderer": "^15.6.1",
     "react-bootstrap": "^0.30.7"
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.10",
-    "react": "^15.6.1",
-    "react-dnd": "^2.5.1",
-    "react-dnd-html5-backend": "^2.5.1",
-    "react-dom": "^15.6.1"
+    "prop-types": "^15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "eslint": "^4.7.2",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.1.0",
-    "react-test-renderer": "^15.6.1",
-    "jsdom": "^11.2.0"
+    "jsdom": "^11.3.0",
+    "react-test-renderer": "^15.6.1"
   },
   "dependencies": {
     "lodash": "^4.17.4",

--- a/src/components/DefaultArea.js
+++ b/src/components/DefaultArea.js
@@ -77,7 +77,8 @@ class DefaultArea extends React.Component {
           }}>
             <Glyphicon glyph="fullscreen" title="Click to show expanded verses" style={{cursor: "pointer"}}/>
             {this.state.modalVisibility ?
-              <MyLanguageModal {...this.props}
+              <MyLanguageModal
+                projectDetailsReducer={this.props.projectDetailsReducer}
                 show={this.state.modalVisibility}
                 targetLangBible={bibles.targetLanguage}
                 chapter={reference.chapter}

--- a/src/components/DefaultArea.js
+++ b/src/components/DefaultArea.js
@@ -76,8 +76,8 @@ class DefaultArea extends React.Component {
             this.setState({modalVisibility: true});
           }}>
             <Glyphicon glyph="fullscreen" title="Click to show expanded verses" style={{cursor: "pointer"}}/>
-            {this.state.modalVisibility ? 
-              <MyLanguageModal
+            {this.state.modalVisibility ?
+              <MyLanguageModal {...this.props}
                 show={this.state.modalVisibility}
                 targetLangBible={bibles.targetLanguage}
                 chapter={reference.chapter}

--- a/src/components/MyLanguageModal.js
+++ b/src/components/MyLanguageModal.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { Modal, Glyphicon } from 'react-bootstrap';
 import MyTargetVerse from './MyTargetVerse';
 import ReactDOM from 'react-dom';
+import style from '../css/Style';
 
 class MyLanguageModal extends Component {
 
@@ -16,7 +17,8 @@ class MyLanguageModal extends Component {
   }
 
   render() {
-    let { show, onHide, targetLangBible, chapter, currentVerse } = this.props;
+    let { show, onHide, targetLangBible, chapter, currentVerse, projectDetailsReducer} = this.props;
+    const title = projectDetailsReducer.manifest.project.name;
     let MyTargetLanguage = [];
     if (show) {
       for (let key in targetLangBible[chapter]) {
@@ -52,7 +54,8 @@ class MyLanguageModal extends Component {
     return (
       <Modal show={show} onHide={onHide} bsSize="lg" aria-labelledby="contained-modal-title-sm">
         <Modal.Header style={{ backgroundColor: "var(--accent-color-dark)" }}>
-          <Modal.Title id="contained-modal-title-sm">
+          <Modal.Title id="contained-modal-title-sm" style={style.modalTitle}>
+            {title}
             <Glyphicon
                 onClick={onHide}
                 glyph={"remove"}

--- a/src/css/Style.js
+++ b/src/css/Style.js
@@ -75,7 +75,7 @@ var style = {
     display: 'flex',
     flexDirection: 'column',
     padding: '5px 15px 0 15px',
-    height: "100%" 
+    height: "100%"
   },
   editArea: {
     flex: 'auto',
@@ -83,6 +83,10 @@ var style = {
     flexDirection: 'column',
     padding: '5px 15px 0 15px',
     height: "100%"
+  },
+  modalTitle: {
+    textAlign: "center",
+    color: "var(--reverse-color)"
   }
 };
 


### PR DESCRIPTION
#### This pull request addresses:

Addresses Issue https://github.com/unfoldingWord-dev/translationCore/issues/1279 for the expanded my language's title


#### How to test this pull request:

Go to tW tool for a project and in "Step 2" expand the scripture of the selected verse to view the chapter. The title of the modal should be the name of the Bible book.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/82)
<!-- Reviewable:end -->
