### PR TITLE
Feature 3086/show invalidated selection

### DIFF
--- a/src/components/DefaultArea.js
+++ b/src/components/DefaultArea.js
@@ -27,12 +27,6 @@ class DefaultArea extends React.Component {
     let verseTextSpans = <span>{verseText}</span>;
     if (selections && selections.length > 0) {
       let _selectionArray = selectionArray(verseText, selections);
-      selections.forEach(selection => {
-        if (occurrencesInString(verseText,selection.text) !== selection.occurrences) {
-          // validate selections and remove ones that do not apply
-          this.props.actions.validateSelections(verseText);
-        }
-      });
       verseTextSpans = _selectionArray.map((selection, index) => {
         let style = selection.selected ? { backgroundColor: 'var(--highlight-color)' } : {};
         return (

--- a/src/components/DefaultArea.js
+++ b/src/components/DefaultArea.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 // helpers
 import {
   selectionArray,
-  occurrencesInString,
   normalizeString
 } from '../utils/selectionHelpers';
 // components
@@ -92,9 +91,6 @@ class DefaultArea extends React.Component {
 
 DefaultArea.propTypes = {
   translate: PropTypes.func.isRequired,
-  actions: PropTypes.shape({
-    validateSelections: PropTypes.func,
-  }).isRequired,
   contextIdReducer: PropTypes.shape({
     contextId: PropTypes.object
   }).isRequired,


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Moved selection checking out of tool.  It is now in tCore action to support all editors.

#### Please include detailed Test instructions for your pull request:
- test as part of https://github.com/unfoldingWord-dev/translationCore/pull/4283

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/versecheck/102)
<!-- Reviewable:end -->
